### PR TITLE
fixed variable assignment bug introduced after 2015b speed improvements

### DIFF
--- a/@FLOWobj/drainagebasins.m
+++ b/@FLOWobj/drainagebasins.m
@@ -109,7 +109,7 @@ elseif nargin == 1;
         if D(ixctemp(r)) == 0;
             DBcounter = DBcounter+1;
             D(ixctemp(r)) = DBcounter;
-            outlets(DBcounter) = ixctemp;
+            outlets(DBcounter) = ixctemp(r);
         end
         D(ixtemp(r)) = D(ixctemp(r));
     end


### PR DESCRIPTION
This fixes usage of the `drainagebasins` function.

A bug in` /@FLOWobj/drainagebasins.m` was introduced in the **4/3/2016** changes. It provoked a _"Subscripted assignment dimension mismatch"_ error when using `drainagebasins(FD)` (i.e. with `nargin=1`).
According to a git diff with the former version, there was a simple **variable indexing error** which is  now corrected.

N.B. I tested the function using 2015a.