### PR TITLE
specify path to exampleDEM.mat

### DIFF
--- a/demos/demo_modifystreamnet.m
+++ b/demos/demo_modifystreamnet.m
@@ -21,7 +21,7 @@ function demo_modifystreamnet
 narginchk(0,0)
 nargoutchk(0,0)
 
-load exampledem
+load '../DEMdata/exampleDEM.mat'
 DEM = GRIDobj(X,Y,dem);
 FD  = FLOWobj(DEM,'preprocess','carve');
 S   = STREAMobj(FD,'minarea',100);

--- a/demos/demo_modifystreamnet.m
+++ b/demos/demo_modifystreamnet.m
@@ -21,7 +21,7 @@ function demo_modifystreamnet
 narginchk(0,0)
 nargoutchk(0,0)
 
-load '../DEMdata/exampleDEM.mat'
+load exampleDEM.mat
 DEM = GRIDobj(X,Y,dem);
 FD  = FLOWobj(DEM,'preprocess','carve');
 S   = STREAMobj(FD,'minarea',100);


### PR DESCRIPTION
not sure if the exampleDEM.mat file used to live in the same folder as the example code, but it is located in the DEMdata folder in the newest version. I simply specify a relative path, based on the existing file structure.