### PR TITLE
curvature: Fix inaccuracies in the implemented Evans method

### DIFF
--- a/@GRIDobj/curvature.m
+++ b/@GRIDobj/curvature.m
@@ -124,13 +124,19 @@ else
     correctedges = true;
     shape = 'valid';
 end
-    
-% First-order partial derivatives:
-[fx,fy] = gradient(dem,cs);
 
 if correctedges
     dem = padarray(dem,[1 1],'symmetric');
 end
+
+% First-order partial derivatives:
+% kernel for dz/dx
+kernel = [-1 0 1; -1 0 1; -1 0 1]./(6*cs);
+fx = conv2(dem,kernel,shape);
+% kernel for dz/dy
+kernel = [1 1 1; 0 0 0; -1 -1 -1]./(6*cs);
+fy = conv2(dem,kernel,shape);
+
 % Second order derivatives according to Evans method (see Olaya 2009)
 %
 % z1 z2 z3
@@ -159,9 +165,9 @@ switch ctype
     case 'profc'
         curv = - (fx.^2 .* fxx + 2*fx.*fy.*fxy + fy.^2.*fyy)./((fx.^2 + fy.^2).*(1 + fx.^2 + fy.^2).^(3/2));
     case 'tangc'
-        curv = - (fy.^2 .* fxx + 2*fx.*fy.*fxy + fx.^2.*fyy)./((fx.^2 + fy.^2).*(1 + fx.^2 + fy.^2).^(1/2));
+        curv = - (fy.^2 .* fxx - 2*fx.*fy.*fxy + fx.^2.*fyy)./((fx.^2 + fy.^2).*(1 + fx.^2 + fy.^2).^(1/2));
     case 'planc'
-        curv = - (fy.^2 .* fxx + 2*fx.*fy.*fxy + fx.^2.*fyy)./((fx.^2 + fy.^2).^(3/2));
+        curv = - (fy.^2 .* fxx - 2*fx.*fy.*fxy + fx.^2.*fyy)./((fx.^2 + fy.^2).^(3/2));
     case 'meanc'
         curv = - ((1+fy.^2).*fxx - 2.*fxy.*fx.*fy + (1+fx.^2).*fyy)./ ...
             (2.* (fx.^2+fy.^2+1).^(3/2));


### PR DESCRIPTION
Looking through Schmidt et al. (2003) I found what I believe to be 3 small inaccuracies in `curvature.m`:

1. As far as I can tell the `gradient` function is not producing the desired `fx` and `fy` for the Evans method, using only 2 neighbours rather than the desired 6. Additionally, `gradient` calculates `fx` in the opposite direction.
2. It seems like `+ 2 * fx .* fy .* fxy` should be `- 2 * fx .* fy .* fxy` in the tangential curvature.
3. It seems like `+ 2 * fx .* fy .* fxy` should be `- 2 * fx .* fy .* fxy` in the planform curvature.

I am not an expert, so please let me know if I am mistaken.